### PR TITLE
La til punkt om krav av vitenskapelig metode

### DIFF
--- a/Program.markdown
+++ b/Program.markdown
@@ -159,3 +159,4 @@ Forskning som er offentlig finansiert (inkludert rådata, programkode og metoder
 - All offentlig finansiert forskning må publiseres åpent og være fritt tilgjengelig.
 - Fjerne programvarepatenter og biologiske patenter. Andre typer patenter skal vurderes.
 - Data og programvare finansiert gjennom offentlige midler må være åpent og fritt tilgjengelig.
+- Kreve at all offentlig finansiert forskning må overholde strenge regler og rammeverk for den vitenskapelige metode for å unngå subjektivitet som kan påvirke resultat og konklusjon fra individer, interesseorganisasjoner, religion eller lignende.


### PR DESCRIPTION
Dette programendringsforslaget fra landsmøtet i 2016 bør reverseres så fort som mulig grunnet at vi nå har senket vår standard for akseptert vitenskap betydelig. Middelthun argumenterte at vi ikke trengte å ha noe eksplisitt skrevet som forklarer hvordan vi forholder oss til vitenskap, men jeg tror i dag at det er viktigere enn noensinne å foreta et grundig og etablert standpunkt på dette temaet. Spesielt siden en av våre kjerneverdier handler om kunnskap, men også fordi det finnes flere interesseorganisasjoner med offentlig støtte som nå kunne manipulert våre manglende rammer for å få lånt kredibilitet til svada-vitenskap. Vi som skal basere alle våre avgjørelser på forskning og god kunnskap er avhengige av å være satt inn i det meste av den vitenskapelige metoden som individer og ha dem dypt forankret i våre verdier og kanskje også vedtekter for å unngå utvanning, mistolking, misforståelser, og feilaktige beslutninger/støtte.

Fixes #6.